### PR TITLE
Add Temporal workflow determinism test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
         "@temporalio/client": "^1.11.8",
         "@temporalio/worker": "^1.11.8",
         "uuid": "^11.1.0"
+      },
+      "devDependencies": {
+        "@temporalio/testing": "^1.11.8"
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -514,6 +517,23 @@
       "dependencies": {
         "long": "^5.2.3",
         "protobufjs": "^7.2.5"
+      }
+    },
+    "node_modules/@temporalio/testing": {
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/@temporalio/testing/-/testing-1.11.8.tgz",
+      "integrity": "sha512-FC6A2YFDH6CDp7eeZ9aW9RDSzGxQqH6Old5UxBvIk5ZFgsCMOltpWqYMTIrv9EQbe6xMOTgPjP/6XgAqvIPj/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@temporalio/activity": "1.11.8",
+        "@temporalio/client": "1.11.8",
+        "@temporalio/common": "1.11.8",
+        "@temporalio/core-bridge": "1.11.8",
+        "@temporalio/proto": "1.11.8",
+        "@temporalio/worker": "1.11.8",
+        "@temporalio/workflow": "1.11.8",
+        "abort-controller": "^3.0.0"
       }
     },
     "node_modules/@temporalio/worker": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Hello",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test",
     "worker": "node worker.js",
     "start": "node client.js"
   },
@@ -16,5 +16,8 @@
     "@temporalio/client": "^1.11.8",
     "@temporalio/worker": "^1.11.8",
     "uuid": "^11.1.0"
+  },
+  "devDependencies": {
+    "@temporalio/testing": "^1.11.8"
   }
 }

--- a/test/workflow.test.js
+++ b/test/workflow.test.js
@@ -1,0 +1,43 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { TestWorkflowEnvironment } from '@temporalio/testing';
+import { Worker } from '@temporalio/worker';
+import { v4 as uuidv4 } from 'uuid';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import * as activities from '../activities/index.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const workflowsPath = join(__dirname, '../workflows');
+
+// Verify that running a previously recorded history does not throw,
+// which indicates that the workflow remains deterministic.
+
+test('checkout workflow determinism', async () => {
+  const env = await TestWorkflowEnvironment.createLocal();
+  const worker = await Worker.create({
+    connection: env.nativeConnection,
+    workflowsPath,
+    activities,
+    taskQueue: 'determinism',
+  });
+
+  let history;
+  try {
+    history = await worker.runUntil(async () => {
+      const handle = await env.workflowClient.start('checkoutWorkflow', {
+        args: ['customer-123'],
+        taskQueue: 'determinism',
+        workflowId: 'wf-' + uuidv4(),
+      });
+      await handle.result();
+      return await handle.fetchHistory();
+    });
+
+    await Worker.runReplayHistory({ workflowsPath }, history);
+  } finally {
+    await env.teardown();
+  }
+
+  assert.ok(history?.events?.length > 0, 'history should contain events');
+});


### PR DESCRIPTION
## Summary
- add dev dependency `@temporalio/testing`
- use `node --test` for running tests
- add `test/workflow.test.js` that verifies workflow determinism with `Worker.runReplayHistory`

## Testing
- `npm test` *(fails: Failed to start ephemeral server)*

------
https://chatgpt.com/codex/tasks/task_e_68414c5bcc048320b5ffe6f83c3696b1