### PR TITLE
Add simple browser cart UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ To experiment with the shopping cart workflow, start the express server:
 npm run server
 ```
 
+Once the server is running, open `http://localhost:3000/` in your browser. A
+very small web interface lets you pick items, add them to a cart and perform
+checkout. The interface communicates with the API described below.
+
 Available endpoints:
 
 - `GET /items` – list available items

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,68 @@
+let cartId = null;
+let catalog = {};
+
+async function fetchItems() {
+  const res = await fetch('/items');
+  catalog = await res.json();
+  const itemsDiv = document.getElementById('items');
+  itemsDiv.innerHTML = '';
+  Object.entries(catalog).forEach(([id, item]) => {
+    const div = document.createElement('div');
+    div.className = 'item';
+    div.innerHTML = `<strong>${item.name}</strong> - $${item.price} ` +
+      `<button data-id="${id}">Add</button>`;
+    itemsDiv.appendChild(div);
+  });
+  itemsDiv.addEventListener('click', async (e) => {
+    if (e.target.tagName === 'BUTTON') {
+      await addToCart(e.target.dataset.id);
+    }
+  });
+}
+
+async function ensureCart() {
+  if (!cartId) {
+    const res = await fetch('/cart/create', { method: 'POST', headers: { 'Content-Type': 'application/json' } });
+    const data = await res.json();
+    cartId = data.cartId;
+    document.getElementById('checkoutBtn').disabled = false;
+  }
+}
+
+async function addToCart(itemId) {
+  await ensureCart();
+  await fetch(`/cart/${cartId}/add`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ itemId })
+  });
+  await refreshCart();
+}
+
+async function refreshCart() {
+  if (!cartId) return;
+  const res = await fetch(`/cart/${cartId}`);
+  const cart = await res.json();
+  const ul = document.getElementById('cartItems');
+  ul.innerHTML = '';
+  cart.forEach(item => {
+    const li = document.createElement('li');
+    li.textContent = `${item.name} x${item.qty} - $${item.price * item.qty}`;
+    ul.appendChild(li);
+  });
+}
+
+async function checkout() {
+  if (!cartId) return;
+  const res = await fetch(`/cart/${cartId}/checkout`, { method: 'POST' });
+  const data = await res.json();
+  alert(data.result);
+  cartId = null;
+  document.getElementById('cartItems').innerHTML = '';
+  document.getElementById('checkoutBtn').disabled = true;
+}
+
+window.onload = () => {
+  fetchItems();
+  document.getElementById('checkoutBtn').addEventListener('click', checkout);
+};

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Shopping Cart</title>
+    <style>
+        body { font-family: Arial, sans-serif; max-width: 600px; margin: auto; }
+        h1 { text-align: center; }
+        .item { border: 1px solid #ccc; padding: 10px; margin-bottom: 5px; }
+        .cart { margin-top: 20px; }
+        button { margin-left: 10px; }
+    </style>
+</head>
+<body>
+<h1>Shop</h1>
+<div id="items"></div>
+<div class="cart">
+    <h2>Cart</h2>
+    <ul id="cartItems"></ul>
+    <button id="checkoutBtn" disabled>Checkout</button>
+</div>
+<script src="app.js"></script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1,9 +1,13 @@
 import express from 'express';
 import { Connection, Client } from '@temporalio/client';
 import { v4 as uuidv4 } from 'uuid';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
 
 const app = express();
 app.use(express.json());
+const __dirname = dirname(fileURLToPath(import.meta.url));
+app.use(express.static(join(__dirname, 'public')));
 
 const catalog = {
   apple: { name: 'Apple', price: 1 },


### PR DESCRIPTION
## Summary
- serve static files from new `public` folder
- add a basic HTML/JS interface for managing the cart
- document how to use the web interface

## Testing
- `npm install`
- `npm test` *(fails: Failed to start ephemeral server)*

------
https://chatgpt.com/codex/tasks/task_e_68419e1024208320b10d66d2aca23d11